### PR TITLE
Update new_field.py

### DIFF
--- a/source/new_field.py
+++ b/source/new_field.py
@@ -75,8 +75,12 @@ def addFieldFile(operation, db, collection_name, new_field_file, name, method):
         print(f'{new_field_file} file does not exist.')
         return
 
+    print(f"{datetime.datetime.now()} : Running addFieldFile")
+
     # Import the update information
     update_data = pd.read_csv(new_field_file)
+
+    print(f"{datetime.datetime.now()} : CSV read")
 
     # Get the fields:
     column_names = update_data.columns.to_list()
@@ -86,6 +90,8 @@ def addFieldFile(operation, db, collection_name, new_field_file, name, method):
 
     field_to_match = column_names[0]  # The header from the first column will be the field to match
     new_field = column_names[1]  # The header from the second column will be the update field
+
+    print(f"{datetime.datetime.now()} : Field to match ({field_to_match}), New field ({new_field})")
 
     # Get the values from the columns
     values_to_match = update_data[field_to_match].values
@@ -100,15 +106,23 @@ def addFieldFile(operation, db, collection_name, new_field_file, name, method):
         return
 
     # Insert metadata about the update process
+    print(f"{datetime.datetime.now()} : Creating log file")
     process_id = log_functions.insertLog(db, name, method, operation, collection_name)
+    print(f"{datetime.datetime.now()} : Log file created")
+
 
     # Prepare data for insertion into the files collection
+
+    print(f"{datetime.datetime.now()} : Preparing json from csv")
     files_data = {
         "log_id": str(process_id),
         "operation": operation,
         field_to_match: values_to_match.tolist(),  # Convert numpy array to Python list
         new_field: new_values.tolist()  # Convert numpy array to Python list
     }
+    print(f"{datetime.datetime.now()} : json created")
+
+    print(f"{datetime.datetime.now()} : Inserting new data into collection")
 
     # Access or create the files collection
     files_collection = db["update_files"]
@@ -116,24 +130,29 @@ def addFieldFile(operation, db, collection_name, new_field_file, name, method):
 
     # Prepare bulk update operations
     bulk_updates = []
+    print(f"{datetime.datetime.now()} : preapering bulk updates")
     for value_to_match, new_value in zip(values_to_match, new_values):
         update_criteria = {field_to_match: value_to_match}
-        previous_document = collection.find_one(update_criteria)
+        # previous_document = collection.find_one(update_criteria) # NEW 
 
-        if previous_document:
-            updated_log = log_functions.updateLog(previous_document, process_id, operation, new_field, "Non-existing", new_value)
-            bulk_updates.append(
-                UpdateOne(update_criteria, {"$set": {new_field: new_value, "log": updated_log}})
-            )
+        # Directly append update operation, assuming document exists
+        updated_log = log_functions.updateLog(None, process_id, operation, new_field, "Non-existing", new_value)
+        bulk_updates.append(
+            UpdateOne(update_criteria, {"$set": {new_field: new_value, "log": updated_log}})
+        )
+    print(f"{datetime.datetime.now()} : bulk updates ready")
 
     # Execute bulk updates for matched documents
+    print(f"{datetime.datetime.now()} : starting bulk update")
     if bulk_updates:
         result = collection.bulk_write(bulk_updates)
         updates_made = result.modified_count
     else:
         updates_made = 0
+    print(f"{datetime.datetime.now()} : bulk update finished")
 
     # Handle documents that are not inside the file
+    print(f"{datetime.datetime.now()} : managing logs for files not updated")
     all_documents = collection.find()
     unmatched_updates_made = 0
     unmatched_bulk_updates = []
@@ -144,6 +163,9 @@ def addFieldFile(operation, db, collection_name, new_field_file, name, method):
             unmatched_bulk_updates.append(
                 UpdateOne(update_criteria, {"$set": {new_field: None, "log": updated_log}})
             )
+    print(f"{datetime.datetime.now()} : finished managing logs for files not updated")
+
+    print(f"{datetime.datetime.now()} : Execute bulk updates for unmatched documents")
 
     # Execute bulk updates for unmatched documents
     if unmatched_bulk_updates:
@@ -151,6 +173,10 @@ def addFieldFile(operation, db, collection_name, new_field_file, name, method):
         unmatched_updates_made = result.modified_count
 
     total_updates_made = updates_made + unmatched_updates_made
+
+    print(f"{datetime.datetime.now()} : finish Execute bulk updates for unmatched documents")
+
+    print(f"{datetime.datetime.now()} : New data inserted into collection")
 
     # If no updates were made, remove the log entry
     if total_updates_made == 0:


### PR DESCRIPTION
the line # previous_document = collection.find_one(update_criteria) was commented. The find_one operation within the loop is a significant performance bottleneck. Avoid it by directly appending UpdateOne operations, assuming the document exists or skipping the check when not necessary.