### PR TITLE
Created upsert.py and new functions that "force" updates

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -7,7 +7,7 @@
 # ----------
 # General information
 # ----------
-operation='' # Operations: insert, update_one, update_all, update_with_file, restore_one, restore_all, add_empty_field, add_field_with_file, rename_field, remove_field
+operation='' # Operations: insert, update_one, update_all, update_with_file, upsert_one, upsert_all, upsert_with_file, restore_one, restore_all, add_empty_field, add_field_with_file, rename_field, remove_field
 name='' # Name of the person that does this operation.
 method='' # Method used to obtain or modify the data (e.g. Raw data EGAPRO).
 database_name='' # Name of the database.
@@ -19,16 +19,16 @@ collection_name='' # Collection to be managed (analysis, dac, dataset, experimen
 # ---------
 # Insert needs:
 # ----------
-json_documents=f'path/to/json/or/directory' # Path to a json document or directory to be inserted.
+json_documents=f'' # Path to a json document or directory to be inserted.
 
 # ----------
-# Update needs (update_field is always needed):
+# Update and upsert operations need (update_field is always needed):
 # ----------
 update_field='' # Target field to be updated.
 new_value='' # New value for the field (no need if using a file).
-update_criteria={'field_to_match':'value_to_match'} # Criteria to update one, pick a field with unique values.
-# If using update_with_file, please provide the csv with the information.
-update_file = 'path/to/csv/or/directory' # If you want to add a list as a new value, separate the values with ";". You can link to a directory full of csv files, too.
+update_criteria={'':''} # Criteria to update one, pick a field with unique values.
+# If using update_with_file or upsert_with_file, please provide the csv with the information.
+update_file = '' # If you want to add a list as a new value, separate the values with ";". You can link to a directory full of csv files, too.
 
 # ----------
 # Restore needs:

--- a/source/upsert.py
+++ b/source/upsert.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+
+"""upsert.py  :  Update embedded or non-embedded fields in a collection, even if the fields are not already present in the documents """
+
+__author__ = "Akiris Moctezuma"
+__version__ = "0.1"
+__maintainer__ = "Aldar Cabrelles"
+__email__ = "aldar.cabrelles@crg.eu"
+__status__ = "development"
+
+from . import log_functions
+import pandas as pd
+import os
+from pymongo import UpdateOne
+from os import listdir
+from os.path import isfile, join, isdir
+import pandas as pd
+import re
+
+def upsertOne(operation, db, collection_name, update_criteria, update_field, new_value, name, method):
+    """
+    Update the value of an embedded or non-embedded field in one document present in a specific collection from the database.
+    If the field doesn't exist, the program forcefully creates it at the specified location and adds the given value.
+    """
+    # Access the collection:
+    collection = db[collection_name]
+    
+    # Find the document before the update to retrieve the previous value
+    previous_document = collection.find_one(update_criteria)
+    
+    if previous_document:
+        updates_made = 0
+
+        # Convert new_value to a list if it contains a semicolon, otherwise use it as it is
+        new_value_list = new_value.split(";") if ";" in new_value else new_value
+
+        # Retrieve the current value using dot notation (if available)
+        current_value = previous_document
+        # Use dot notation to access nested fields
+        for key in update_field.split("."):
+            current_value = current_value.get(key)
+            if current_value is None:
+                break
+               
+        # If the field doesn't exist in the document, explicitly set `None` as the current value
+        if current_value is None:
+            print(f"Field {update_field} doesn't exist in the document. Creating field and setting new value.")
+            # Update the log field in the JSON document
+            updated_log = log_functions.updateLog(previous_document, process_id, operation, update_field, None, new_value_list)
+        elif current_value != new_value_list:
+            print(f"Field {update_field} exists and has a different value in document with stable_id: {list(update_criteria.values())[0]}. Updating the field.")
+            # Update the log field in the JSON document
+            updated_log = log_functions.updateLog(previous_document, process_id, operation, update_field, current_value, new_value_list)
+        else:
+            print(f"Field {update_field} exists but has the same value in document with stable_id: {list(update_criteria.values())[0]}. No update required.")
+            return  # Exit the function without performing the update if values are the same
+
+        # Insert metadata about the update process in the log_details collection
+        process_id = log_functions.insertLog(db, name, method, operation, collection_name)
+
+        # Update the document with the new data
+        result = collection.update_one(update_criteria, {"$set": {update_field: new_value_list, "log": updated_log}})
+            
+        # Print whether the document was updated or not
+        if result.modified_count > 0:
+            updates_made += 1
+            print(f'Field {update_field} updated successfully in the document with stable_id: {list(update_criteria.values())[0]}')
+            print(f'Previous value: {current_value}, New value: {new_value_list}')
+            print('')
+        # If no updates were made, remove the metadata in the log_details collection 
+        elif updates_made == 0:
+            log_functions.deleteLog(db, str(process_id))
+            print("No changes were made.")
+    else:
+        print(f"The document you are searching for is not in the collection.")
+
+def upsertAll(operation, db, collection_name, update_field, new_value, name, method):
+    """
+    Update the value of an embedded or non-embedded field in all the documents present in a specific collection from the database.
+    If the field doesn't exist, the program forcefully creates it at the specified location and adds the given value.
+    """
+    # Access the collection
+    collection = db[collection_name]
+
+    # Prepare a list of bulk update operations
+    bulk_updates = []
+
+    # Fetch all documents in the collection
+    previous_documents = collection.find()
+
+    # Insert metadata about the update process in the log_details collection
+    process_id = log_functions.insertLog(db, name, method, operation, collection_name)
+
+    # Convert new_value to a list if it contains a semicolon, otherwise use it as it is
+    new_value_list = new_value.split(";") if ";" in new_value else new_value
+
+    # Loop through each document
+    for document in previous_documents:
+        # Retrieve the stable_id from the document
+        stable_id = document.get('stable_id', 'Unknown stable_id')
+
+        # Retrieve the current value using dot notation (if available)
+        current_value = document
+        # Use dot notation to access nested fields
+        for key in update_field.split("."):
+            current_value = current_value.get(key)
+            if current_value is None:
+                break
+
+        if current_value is None:
+            # If the field is set as Null or doesn't exist, create it and set the new value
+            print(f"Field {update_field} doesn't exist in document with stable_id: {stable_id}. Creating field and setting new value.")
+            updated_log = log_functions.updateLog(document, process_id, operation, update_field, None, new_value_list)
+            bulk_updates.append(UpdateOne(
+                {"_id": document["_id"]},
+                {"$set": {update_field: new_value_list, "log": updated_log}}
+            ))
+        elif current_value != new_value_list:
+            # If the field exists but the value is different, update it
+            print(f"Field {update_field} exists and has a different value in document with stable_id: {stable_id}. Updating the field.")
+            updated_log = log_functions.updateLog(document, process_id, operation, update_field, current_value, new_value_list)
+            bulk_updates.append(UpdateOne(
+                {"_id": document["_id"]},
+                {"$set": {update_field: new_value_list, "log": updated_log}}
+            ))
+        else:
+            # If the field exists and the value is the same, no update is needed
+            print(f"Field {update_field} exists but has the same value in document with stable_id: {stable_id}. No update required.")
+
+    # Execute the bulk update operations
+    if bulk_updates:
+        result = collection.bulk_write(bulk_updates)
+        updates_made = result.modified_count
+
+        if updates_made == 0:
+            log_functions.deleteLog(db, str(process_id))
+            print("No changes were made.")
+        else:
+            print(f'{updates_made} document(s) updated successfully. New value for {update_field}: {new_value_list}')
+    else:
+        log_functions.deleteLog(db, str(process_id))
+        print("No changes were necessary. All values were already up to date.")
+
+def upsertFile(operation, db, collection_name, update_file, name, method):
+    """
+    Update the value of an embedded or non-embedded field in multiple documents with information from a CSV file.
+    If the field doesn't exist, the program forcefully creates it at the specified location and adds the given value.
+    Supports a single CSV file or multiple files in a directory.
+    """
+    chunk_size = 10000  # Establishing the maximum number of lines that a CSV can have before being split
+
+    # Determine if it's a single file or a directory
+    if os.path.exists(update_file) and (isfile(update_file) or isdir(update_file)):
+        # Obtain list of elements found in the directory, turn them into iterable lists
+        if isfile(update_file):
+            csv_files = [update_file]
+            print("There is 1 file to process.")
+        elif isdir(update_file):
+            csv_files = [update_file + "/" + f for f in listdir(update_file) if isfile(join(update_file, f))]
+            csv_files = sorted(csv_files, key=lambda s: [int(text) if text.isdigit() else text.lower() for text in re.split('([0-9]+)', s)])
+            print(f'There is/are {len(csv_files)} file(s) to process.')
+
+        # Begin loop
+        for f in csv_files:
+            # Time to loop it all
+            if f[-4:]==".csv":
+                # Import the update information
+                print(f'Importing {f}')
+                update_data = pd.read_csv(f)
+
+                # Get the fields:
+                column_names = update_data.columns.to_list()
+                field_to_match = column_names[0]  # The header from the first column will always be the field to match
+                update_field = column_names[1]  # The header from the second column will always be the update field
+
+                # Get the values from the columns
+                values_to_match = update_data[field_to_match].values
+                new_values = update_data[update_field].values
+
+                print(f'There are {len(values_to_match)} objects to update.')
+
+                # Access the collection:
+                collection = db[collection_name]
+
+                # Access or create the files collection:
+                files_collection = db["update_files"]
+
+                # Split the data into chunks and insert each chunk into the 'update_files' collection
+                num_chunks = (len(values_to_match) + chunk_size - 1) // chunk_size
+
+                # Begin processing chunks
+                for i in range(num_chunks):
+                    print(f"Processing chunk number {i+1}.")
+
+                    # Calculate the start and end indices for each chunk
+                    start_idx = i * chunk_size
+                    end_idx = min(start_idx + chunk_size, len(values_to_match))
+
+                    # Define chunk values for this batch
+                    chunk_values_to_match = values_to_match[start_idx:end_idx].tolist()
+                    chunk_new_values = new_values[start_idx:end_idx].tolist()
+
+                    # Insert metadata about the update process in the log_details collection
+                    process_id = log_functions.insertLog(db, name, method, operation, collection_name)
+
+                    # Track the documents that were actually updated
+                    updated_values_to_match = []
+                    updated_new_values = []
+
+                    # For each row, use the update one function to modify the specific field stated in the file.
+                    updates_made = 0
+                    for value_to_match, new_value in zip(chunk_values_to_match, chunk_new_values):
+
+                        # Convert the string "None" to the Python None type
+                        if pd.isna(new_value) or new_value is None:
+                            new_value_list = None
+                        else:
+                            # Only attempt to split the new_value if it's a string
+                            if isinstance(new_value, str):
+                                new_value_list = new_value.split(";") if ";" in new_value else new_value
+                            else:
+                                new_value_list = new_value  # If it's not a string, use it as is
+
+                        # Stable id of the object to be updated
+                        update_criteria = {field_to_match: value_to_match}
+
+                        # Find the document before the update to retrieve the previous value
+                        previous_document = collection.find_one(update_criteria)
+
+                        if previous_document:
+
+                            # Retrieve the current value using dot notation (if available)
+                            current_value = previous_document
+                            # Use dot notation to access nested fields
+                            for key in update_field.split("."):
+                                current_value = current_value.get(key)
+                                if current_value is None:
+                                    break
+
+                            if current_value is None:
+                                # If the field is set as Null or doesn't exist, create it and set the new value
+                                print(f"Field '{update_field}' doesn't exist in document with stable_id: {value_to_match}. Creating field and setting new value.")
+                                updated_log = log_functions.updateLog(previous_document, process_id, operation, update_field, None, new_value_list)
+                                result = collection.update_one(update_criteria, {"$set": {update_field: new_value_list, "log": updated_log}})
+                                if result.modified_count > 0:
+                                    updates_made += 1
+                                    updated_values_to_match.append(value_to_match)
+                                    updated_new_values.append(new_value)
+                            elif current_value != new_value_list:
+                                print(f"Field '{update_field}' already exists and has a different value in document with stable_id: {value_to_match}. Updating the field.")
+                                updated_log = log_functions.updateLog(previous_document, process_id, operation, update_field, current_value, new_value_list)
+                                result = collection.update_one(update_criteria, {"$set": {update_field: new_value_list, "log": updated_log}})
+                                if result.modified_count > 0:
+                                    updates_made += 1
+                                    updated_values_to_match.append(value_to_match)
+                                    updated_new_values.append(new_value)
+                            else:
+                                print(f"Field '{update_field}' already exists and has the same value in document with stable_id: {value_to_match}. No update required.")
+                        else:
+                            print(f"The document with '{field_to_match}': {value_to_match} is not in the collection.")
+
+                    # Only insert metadata for the documents that were actually updated, a document is created for each chunk  
+                    if updates_made > 0:
+                        files_data = {
+                            "log_id": str(process_id),
+                            "operation": operation,
+                            field_to_match: updated_values_to_match,  # Only updated values
+                            update_field: updated_new_values  # Only new values for updated documents
+                        }
+                        files_collection.insert_one(files_data)
+
+                        print(f"Total number of updates made in chunk number {i+1}: {updates_made}.")
+                    else:
+                        log_functions.deleteLog(db, str(process_id))
+                        print(f"No changes were made in chunk number {i+1}.")
+            else:
+                print(f"{f} is not a CSV file.")
+        print("Updates finished!")
+    else:
+        print(f"{update_file} file or directory does not exist.")

--- a/tools.py
+++ b/tools.py
@@ -12,7 +12,7 @@ __status__ = "development"
 import sys
 from pymongo import MongoClient
 import conf
-from source import insert, update_value, restore_value, rename_field, new_field, remove_field, mongoConnection
+from source import insert, update_value, restore_value, rename_field, new_field, remove_field, mongoConnection, upsert
 
 # Functions
 def print_help():
@@ -47,12 +47,21 @@ def run_operation():
     
     elif conf.operation == 'update_one' and conf.update_field != '' and conf.new_value != '':
         update_value.updateOne(conf.operation, db, conf.collection_name, conf.update_criteria, conf.update_field, conf.new_value, conf.name, conf.method)
-    
+
     elif conf.operation == 'update_all' and conf.update_field != '' and conf.new_value != '':
         update_value.updateAll(conf.operation, db, conf.collection_name, conf.update_field, conf.new_value, conf.name, conf.method)
 
     elif conf.operation == 'update_with_file' and conf.update_file != '':
         update_value.updateFile(conf.operation, db, conf.collection_name, conf.update_file, conf.name, conf.method)
+
+    elif conf.operation == 'upsert_one' and conf.update_field != '' and conf.new_value != '':
+        upsert.upsertOne(conf.operation, db, conf.collection_name, conf.update_criteria, conf.update_field, conf.new_value, conf.name, conf.method)
+
+    elif conf.operation == 'upsert_all' and conf.update_field != '' and conf.new_value != '':
+        upsert.upsertAll(conf.operation, db, conf.collection_name, conf.update_field, conf.new_value, conf.name, conf.method)
+
+    elif conf.operation == 'upsert_with_file' and conf.update_file != '':
+        upsert.upsertFile(conf.operation, db, conf.collection_name, conf.update_file, conf.name, conf.method)
 
     elif conf.operation == 'restore_one' and conf.restore_criteria != '' and conf.log_id != '':
         restore_value.restoreOne(conf.operation, db, conf.collection_name, conf.restore_criteria, conf.log_id, conf.name, conf.method)
@@ -79,7 +88,7 @@ def main():
     if conf.operation == '' and conf.database_name == '' and conf.collection_name == '' and conf.name == '' and conf.method == '':
         # First print help message just in case.
         print_help()
-    elif conf.operation == '' or conf.operation not in ['insert', 'update_one', 'update_all', 'update_with_file', 'restore_one', 'restore_all', 'add_empty_field', 'add_field_with_file', 'rename_field', 'remove_field']:
+    elif conf.operation == '' or conf.operation not in ['insert', 'update_one', 'update_all', 'update_with_file', 'upsert_one', 'upsert_all', 'upsert_with_file', 'restore_one', 'restore_all', 'add_empty_field', 'add_field_with_file', 'rename_field', 'remove_field']:
         print("Operation is missing or wrong.")
     elif conf.database_name == '':
         print("Database is missing.")


### PR DESCRIPTION
The upsert.py script includes three new functions that enable users to create or update both embedded and non-embedded fields in one or more documents within a specified collection. If the target field doesn't exist, these functions will automatically create it at the desired location and assign the specified value. To create or modify an embedded field, users must specify its existing or intended location using dot notation (e.g., created_at.ebi).

upsertOne:
-	Updates a single document in a collection by modifying an embedded or non-embedded field.
-	It logs the operation, checks if the current value of the field is different from the new value, and only updates if necessary.
-	If no update is needed (i.e., the values are the same), it skips the update process.


upsertAll:
-	Updates the specified field for all documents in the collection.
-	Similar to upsertOne, it checks if the field exists and whether the value is different before making updates.
-	It uses bulk operations to apply updates to multiple documents efficiently.
-	It logs the update process and skips updating documents where the field's value is already correct.


upsertFile:
-	Updates multiple documents in a collection based on data from a single CSV file or from multiple files in a directory.
-	It processes the file(s) in chunks for performance efficiency.
-	Each document is updated based on the CSV data, creating new fields if they don't exist and logging the updates.
-	If no updates are needed in a chunk, it skips the process and removes any unnecessary log entries.