### PR TITLE
Disable the creation of the update_files collection

### DIFF
--- a/source/new_field.py
+++ b/source/new_field.py
@@ -70,11 +70,9 @@ def addNullField(operation, db, collection_name, new_field, name, method):
 
 def addFieldFile(operation, db, collection_name, new_field_file, name, method):
     """
-    Update multiple documents with information from a CSV file.
+    Insert a new field with values from a CSV. Only the documents specified in the CSV are assigned their corresponding values,
+    while all other documents in the collection receive a Null value.
     """
-
-    chunk_size=10000 # establishing the maximum number of lines that a CSV can have before being split
-
 
     if not os.path.exists(new_field_file):
         print(f'{new_field_file} file does not exist.')
@@ -84,7 +82,6 @@ def addFieldFile(operation, db, collection_name, new_field_file, name, method):
 
     # Import the update information
     update_data = pd.read_csv(new_field_file)
-
     print(f"{datetime.datetime.now()} : CSV read")
     
     # Get the fields:
@@ -94,20 +91,21 @@ def addFieldFile(operation, db, collection_name, new_field_file, name, method):
         return
 
     field_to_match = column_names[0]  # The header from the first column will be the field to match
-    new_field = column_names[1]  # The header from the second column will be the update field
+    new_field = column_names[1]  # The header from the second column will be the new field
 
     print(f"{datetime.datetime.now()} : Field to match ({field_to_match}), New field ({new_field})")
     
     # Get the values from the columns
-    values_to_match = update_data[field_to_match].values
-    new_values = update_data[new_field].values
+    csv_values_map = dict(zip(update_data[field_to_match], update_data[new_field]))  # Store CSV data in a dictionary
 
     # Access the collection
     collection = db[collection_name]
 
-    # Check if at least one of the values_to_match is in the collection
-    if not collection.find_one({field_to_match: {"$in": list(values_to_match)}}):
-        print("None of the objects are present in the collection.")
+    # Fetch all documents in the collection
+    all_documents = collection.find()
+    
+    if not all_documents:
+        print("No documents found in the collection.")
         return
 
     # Insert metadata about the update process
@@ -115,81 +113,49 @@ def addFieldFile(operation, db, collection_name, new_field_file, name, method):
     process_id = log_functions.insertLog(db, name, method, operation, collection_name)
     print(f"{datetime.datetime.now()} : Log file created")
 
-    # Access or create the files collection
-    files_collection = db["update_files"]
-
-    # Split the data into chunks and insert each chunk into the 'update_files' collection
-    num_chunks = (len(values_to_match) + chunk_size - 1) // chunk_size  # Calculate number of chunks
-    for i in range(num_chunks):
-        start_idx = i * chunk_size
-        end_idx = min(start_idx + chunk_size, len(values_to_match))
-        chunk_values_to_match = values_to_match[start_idx:end_idx].tolist()
-        chunk_new_values = new_values[start_idx:end_idx].tolist()
-
-        files_data = {
-            "log_id": str(process_id),
-            "operation": operation,
-            field_to_match: chunk_values_to_match,
-            new_field: chunk_new_values
-        }
-
-        # Insert the chunk data into the files collection
-        files_collection.insert_one(files_data)
-
-
     # Prepare bulk update operations
     bulk_updates = []
     print(f"{datetime.datetime.now()} : Preparing bulk updates")
-    for value_to_match, new_value in zip(values_to_match, new_values):
-        update_criteria = {field_to_match: value_to_match}
-        # previous_document = collection.find_one(update_criteria) # NEW 
 
-        # Directly append update operation, assuming document exists
-        updated_log = log_functions.updateLog(None, process_id, operation, new_field, "Non-existing", new_value)
-        bulk_updates.append(
-            UpdateOne(update_criteria, {"$set": {new_field: new_value, "log": updated_log}})
-        )
+    matched_documents = 0
+    unmatched_documents = 0
+
+    for doc in all_documents:
+        stable_id = doc.get(field_to_match)  # Get the document's ID
+
+        # Determine if the document is in the CSV file
+        if stable_id in csv_values_map:
+            new_value = csv_values_map[stable_id]  # Assign the CSV value (matched document)
+            matched_documents + 1
+        else:
+            new_value = None  # Assign None for unmatched documents
+            unmatched_documents + 1
+
+        # Get the previous value of the new field (if it exists)
+        previous_value = doc.get(new_field, "Non-existing")  # If field didn't exist, set as "Non-existing"
+
+        # Log the update
+        updated_log = log_functions.updateLog(doc, process_id, operation, new_field, previous_value, new_value)
+
+        # Add the update operation to the batch
+        bulk_updates.append(UpdateOne({"_id": doc["_id"]}, {"$set": {new_field: new_value, "log": updated_log}}))
+
     print(f"{datetime.datetime.now()} : Bulk updates ready")
 
-    # Execute bulk updates for matched documents
-    print(f"{datetime.datetime.now()} : Starting bulk update")
+    # Execute bulk updates
     if bulk_updates:
         result = collection.bulk_write(bulk_updates)
         updates_made = result.modified_count
     else:
         updates_made = 0
+
     print(f"{datetime.datetime.now()} : Bulk update finished")
-    
-    # Handle documents that are not inside the file
-    print(f"{datetime.datetime.now()} : Managing logs for files not updated")
-    all_documents = collection.find()
-    unmatched_updates_made = 0
-    unmatched_bulk_updates = []
-    for doc in all_documents:
-        if field_to_match not in doc or doc[field_to_match] not in values_to_match:
-            update_criteria = {"_id": doc["_id"]}
-            updated_log = log_functions.updateLog(doc, process_id, operation, new_field, "Non-existing", None)
-            unmatched_bulk_updates.append(UpdateOne(update_criteria,{"$set": {new_field: new_value},"$push":{"log":updated_log}}))
-    print(f"{datetime.datetime.now()} : Finished managing logs for files not updated")
-
-    print(f"{datetime.datetime.now()} : Starting bulk updates for unmatched documents")
-    
-    # Execute bulk updates for unmatched documents
-    if unmatched_bulk_updates:
-        result = collection.bulk_write(unmatched_bulk_updates)
-        unmatched_updates_made = result.modified_count
-
-    total_updates_made = updates_made + unmatched_updates_made
-
-    print(f"{datetime.datetime.now()} : Finished bulk updates for unmatched documents")
-
-    print(f"{datetime.datetime.now()} : New data inserted into collection")
 
     # If no updates were made, remove the log entry
-    if total_updates_made == 0:
-        files_collection.delete_one({"log_id": str(process_id)})
+    if updates_made == 0:
         log_functions.deleteLog(db, str(process_id))
         print("No changes were made.")
     else:
-        print(f"There are {updates_made} documents with a filled new field.")
-        print(f"And {unmatched_updates_made} documents with an empty new field.")
+        print(f"Total documents updated: {updates_made}")
+        print(f"There are {matched_documents} documents with a filled new field.")
+        print(f"And {unmatched_documents} documents with an empty new field.")


### PR DESCRIPTION
The creation of documents in the "update_files" collection has been disabled in the following functions:

- addFieldFile (present in new_field.py)
- updateFile (present in update_value.py)
- upsertFile (present in upsert.py) 

Every function has been tested.