### PR TITLE
Restore functions refactoring 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -37,7 +37,7 @@ update_file = ''
 # Restore needs:
 # ----------
 restore_criteria={'stable_id':''} # Criteria for restore_one, the first element should be the field name to match (stable_id), and the second should be the actual stable_id value. 
-log_id='' # Log id to the version to be restored.
+log_id='' # Log id to the version to be restored (restore_all only needs this field).
 
 # ---------
 # Add empty field needs:


### PR DESCRIPTION
restoreOne and restoreAll have been refactored so that they are compatible with the latest changes to the log.

Both functions can:
- restore values that are one or several log entries behind
- restore values that are single strings, booleans and lists
- restore values of embedded fields

Limitations:
- currently, the functions can only restore "update" operations 
- the functions can't restore "Null" values (which makes sense)